### PR TITLE
feat(mnemonic): SQLite memory, code FTS, and web cache for skillgrid-cli

### DIFF
--- a/docs/NOTE.md
+++ b/docs/NOTE.md
@@ -36,6 +36,7 @@
 
 * [?] [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness)
 * [X] [Engram](https://github.com/Gentleman-Programming/engram)
+* [~] **Skillgrid Mnemonic** — v1 on `feat/skillgrid-mnemonic` ([spec](superpowers/specs/2026-08-26-skillgrid-mnemonic-design.md)); replaces Engram when `indexing.profile: mnemonic`
 
 ### Spec driven development
 

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -97,9 +97,11 @@ Built-in SQLite memory + code FTS + web cache via `skillgrid mcp` / `skillgrid s
 
 | # | Track | Plan tasks | Depends on | Outcome |
 |---|-------|------------|------------|---------|
-| 3.5 **∥** | [Mnemonic](specs/2026-08-26-skillgrid-mnemonic-design.md) | [plan](plans/2026-08-26-skillgrid-mnemonic.md) Tasks 1–10+ | Wave 1.2 | `config.d/indexing.yaml`; `skillgrid index`; commented `skillgrid-mnemonic` in `mcp.yaml` |
+| 3.5 **∥** | [Mnemonic](specs/2026-08-26-skillgrid-mnemonic-design.md) | [plan](plans/2026-08-26-skillgrid-mnemonic.md) v1 (Tasks 1–18, 10–16, 12) | Wave 1.2 | **v1 COMPLETE** on `feat/skillgrid-mnemonic`; PR → `release/2` pending |
 
 Teams choose **either** Wave 3.2 (GitNexus primary, demote codegraph/ccc) **or** Wave 3.5 (mnemonic profile, optional GitNexus overlay). Do not enable both as primary memory/index backends without explicit hybrid config.
+
+**v1.1/v2 backlog:** plan Tasks 19–26 (tiered code tools, tree-sitter, branch catalog, temporal decay, Hermes hooks).
 
 ---
 
@@ -182,7 +184,7 @@ flowchart TD
 | **IDD + BDD** | [spec](specs/2026-08-26-idd-bdd-design.md) | [plan](plans/2026-08-26-idd-bdd.md) | active; 0/9 tasks | **P0** |
 | add-mcp | [spec](specs/2026-08-26-add-mcp-integration-design.md) | [plan](plans/2026-08-26-add-mcp-integration.md) | active; 0/7 tasks | P1 |
 | Code indexing (GitNexus) | [spec](specs/2026-08-26-code-indexing-design.md) | *not written* | — | P1 |
-| **Mnemonic** (SQLite memory + code FTS) | [spec](specs/2026-08-26-skillgrid-mnemonic-design.md) | [plan](plans/2026-08-26-skillgrid-mnemonic.md) | active; Task 10 config/docs done | **P1 alt** |
+| **Mnemonic** (SQLite memory + code FTS) | [spec](specs/2026-08-26-skillgrid-mnemonic-design.md) | [plan](plans/2026-08-26-skillgrid-mnemonic.md) | **v1 complete** (18/18 v1 tasks); v1.1/v2 pending; branch `feat/skillgrid-mnemonic` | **P1 alt** |
 | Testing enforcement | [spec](specs/2026-08-26-testing-enforcement-design.md) | [plan](plans/2026-08-26-testing-enforcement.md) | active; 0/9 tasks | P1 |
 | Gryph | [spec](specs/2026-08-26-gryph-integration-design.md) | [plan](plans/2026-08-26-gryph-integration.md) | active; 0/3 tasks | P2 |
 | UI design | [spec](specs/2026-08-26-ui-design-integration-design.md) | *not written* | — | P2 |
@@ -238,4 +240,4 @@ Before Wave 3.2 or Wave 6:
 
 ---
 
-*Last updated: 2026-08-26 — reorder when a spec is promoted or a plan is archived.*
+*Last updated: 2026-08-26 — Mnemonic v1 complete on `feat/skillgrid-mnemonic`; reorder when a spec is promoted or a plan is archived.*

--- a/docs/superpowers/plans/2026-08-26-skillgrid-mnemonic.md
+++ b/docs/superpowers/plans/2026-08-26-skillgrid-mnemonic.md
@@ -1,4 +1,4 @@
-# Skillgrid MemIndex — implementation plan
+# Skillgrid Mnemonic — implementation plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
@@ -8,7 +8,25 @@
 
 **Tech Stack:** Go 1.22+, modernc.org/sqlite, github.com/mark3labs/mcp-go, gopkg.in/yaml.v3 (existing).
 
-**Spec:** [2026-08-26-skillgrid-memindex-design.md](../specs/2026-08-26-skillgrid-memindex-design.md)
+**Spec:** [2026-08-26-skillgrid-mnemonic-design.md](../specs/2026-08-26-skillgrid-mnemonic-design.md)
+
+## Development status
+
+> **Last updated:** 2026-08-26
+
+| Phase | Plan tasks | Status | Git |
+|-------|------------|--------|-----|
+| **v1** | 1–18, 10–16, 12 | **COMPLETE** | branch `feat/skillgrid-mnemonic` @ `254fed5` |
+| v1.1 | 19–22, 24–26 | not started | — |
+| v2 | 23 | not started | — |
+
+**Delivered (v1):** `internal/mnemonic/` — SQLite store, memory + sessions, incremental code index + FTS, web cache, MCP tools (`mem_*`, `code_*`, `web_*`), HTTP `skillgrid serve`, CLI `index` / `web` / `setup`, OpenCode/Kilo plugin + Cursor rule, `config.d/indexing.yaml`, install gating on `profile: mnemonic`.
+
+**Manual verification:** `skillgrid index` (111 files / 304 chunks), Kilo MCP connected, HTTP `/health` ok, `setup kilocode` → `kilo.jsonc` + AGENTS.md.
+
+**Merge:** PR `release/2` ← `feat/skillgrid-mnemonic` — [open compare](https://github.com/devopstales/skillgrid/compare/release/2...feat/skillgrid-mnemonic?expand=1)
+
+**Cutover (post-merge):** set `indexing.profile: mnemonic`; uncomment `skillgrid-mnemonic` in `config.d/mcp.yaml`; demote Engram to opt-in.
 
 ## Global Constraints
 

--- a/docs/superpowers/specs/2026-08-26-skillgrid-mnemonic-design.md
+++ b/docs/superpowers/specs/2026-08-26-skillgrid-mnemonic-design.md
@@ -1,8 +1,8 @@
-# Skillgrid MemIndex — unified SQLite memory + code search
+# Skillgrid Mnemonic — unified SQLite memory + code search
 
-> **STATUS: DRAFT (2026-08-26)**
+> **STATUS: active (2026-08-26)** — v1 implemented on `feat/skillgrid-mnemonic`; promote to **DECIDED** after merge to `release/2`.
 
-**Plan:** [2026-08-26-skillgrid-memindex.md](../plans/2026-08-26-skillgrid-memindex.md)
+**Plan:** [2026-08-26-skillgrid-mnemonic.md](../plans/2026-08-26-skillgrid-mnemonic.md)
 
 **Related:** [2026-08-26-code-indexing-design.md](2026-08-26-code-indexing-design.md), [2026-08-26-add-mcp-integration-design.md](2026-08-26-add-mcp-integration-design.md), [05-skills.md](../../05-skills.md), [NOTE.md](../../NOTE.md)
 


### PR DESCRIPTION
## Summary
- Add **Skillgrid Mnemonic** — built-in SQLite memory, incremental code FTS, and web research cache under `skillgrid-cli/internal/mnemonic/`
- Dual transport: **`skillgrid mcp`** (stdio) + **`skillgrid serve`** (HTTP on `127.0.0.1:7438`) with shared `service/` facade
- CLI: `index`, `web`, `setup` (OpenCode / Kilo / Cursor); install gated on `indexing.profile: mnemonic`
- MCP tools: `mem_*`, `code_*`, `web_cache_*`; OpenCode/Kilo HTTP plugin; docs + `mnemonic-memory` skill
## Test plan
- [ ] `cd skillgrid-cli && go test ./internal/mnemonic/... ./cmd/...`
- [ ] `./bin/skillgrid index` → `index --status` shows files/chunks
- [ ] `./bin/skillgrid serve` → `curl http://127.0.0.1:7438/health`
- [ ] Kilo/Cursor MCP: `mem_save` / `mem_search` round-trip
- [ ] `./bin/skillgrid setup kilocode` → MCP in `kilo.jsonc`, plugin + AGENTS.md
- [ ] DB at `~/.skillgrid/mnemonic/{repo}.sqlite` (e.g. `skillgrid.sqlite`)